### PR TITLE
Fixes a few typos

### DIFF
--- a/azclishell/app.py
+++ b/azclishell/app.py
@@ -106,7 +106,7 @@ def _toolbar_info():
         " [F1]Layout",
         "[F2]Defaults",
         "[F3]Keys",
-        "[Crtl+D]Quit",
+        "[Ctrl+D]Quit",
         tool_val
     ]
     return settings_items

--- a/azclishell/configuration.py
+++ b/azclishell/configuration.py
@@ -27,8 +27,8 @@ GESTURE_INFO = {
     SELECT_SYMBOL['exit_code'] : "get the exit code of the previous command",
     SELECT_SYMBOL['scope'] + '[cmd]' : "set a scope",
     SELECT_SYMBOL['scope'] + ' ' + SELECT_SYMBOL['unscope'] : "go back a scope",
-    "Crtl+N" : "Scroll down the documentation",
-    "Crtl+Y" : "Scroll up the documentation"
+    "Ctrl+N" : "Scroll down the documentation",
+    "Ctrl+Y" : "Scroll up the documentation"
 }
 
 CONFIG_FILE_NAME = 'shell-config'


### PR DESCRIPTION
* Currently when you first open the shell the "Ctrl" is spelled as "Crtl" in the bottom menu.
* If you press F3 to get help on specific keys "Ctrl" is also spelled as "Crtl" in the documentation that is displayed.