### PR TITLE
fixup an issue: IndexError in case that outside cmd is empty

### DIFF
--- a/azclishell/app.py
+++ b/azclishell/app.py
@@ -414,7 +414,7 @@ class Shell(object):
             if text[0] == SELECT_SYMBOL['outside']:
                 cmd = text[1:]
                 outside = True
-                if cmd.split()[0] == 'cd':
+                if cmd.strip() and cmd.split()[0] == 'cd':
                     handle_cd(parse_quotes(cmd))
                     continue_flag = True
                 telemetry.track_ssg('outside', cmd)


### PR DESCRIPTION
Executing empty outside command causes "IndexError: list index out of range".

```
az>> #  <ENTER>

Traceback (most recent call last):
  File "/usr/lib/python3.5/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.5/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/yoichika/.virtualenvs/py3.5/lib/python3.5/site-packages/azclishell/__main__.py", line 71, in <module>
    main(sys.argv[1:])
  File "/home/yoichika/.virtualenvs/py3.5/lib/python3.5/site-packages/azclishell/__main__.py", line 67, in main
    shell_app.run()
  File "/home/yoichika/.virtualenvs/py3.5/lib/python3.5/site-packages/azclishell/app.py", line 558, in run
    b_flag, c_flag, outside, cmd = self._special_cases(text, cmd, outside)
  File "/home/yoichika/.virtualenvs/py3.5/lib/python3.5/site-packages/azclishell/app.py", line 416, in _special_cases
    if cmd.split()[0] == 'cd':
IndexError: list index out of range
```