### PR TITLE
Fixed _get_window_dim which was failing with Python 2.7 on Windows

### DIFF
--- a/azclishell/util.py
+++ b/azclishell/util.py
@@ -49,9 +49,7 @@ def _size_windows():
     csbi = create_string_buffer(22)
     res = windll.kernel32.GetConsoleScreenBufferInfo(h, csbi)
     if res:
-        (bufx, bufy, curx, cury, wattr,
-            left, top, right, bottom,
-            maxx, maxy) = struct.unpack("hhhhHhhhhhh", csbi.raw)
+        (_, _, _, _, _, left, top, right, bottom, _, _) = struct.unpack("hhhhHhhhhhh", csbi.raw)
         sizex = right - left + 1
         sizey = bottom - top + 1
         return sizex, sizey

--- a/azclishell/util.py
+++ b/azclishell/util.py
@@ -19,7 +19,7 @@ def get_window_dim():
 
     if version >= (3, 3):
         return _size_36()
-    elif  platform.system() == 'Windows':
+    elif platform.system() == 'Windows':
         return _size_windows()
     else:
         return _size_27()
@@ -39,6 +39,7 @@ def _size_36():
         return dim[0], dim[1]
     return dim.lines, dim.columns
 
+
 def _size_windows():
     from ctypes import windll, create_string_buffer
     # stdin handle is -10
@@ -54,6 +55,7 @@ def _size_windows():
         sizex = right - left + 1
         sizey = bottom - top + 1
         return sizex, sizey
+
 
 def default_style():
     """ Default coloring """


### PR DESCRIPTION
I tried installing the shell on Windows with Python 2.7, but it would fail on launch complaining about being unable to import get_terminal_size. By looking at the file util.py, I understand that if the platform is Windows then it would go through the Python 3.6 code path and would then fail to import the get_terminal_method if we are running on Python 2.7.

I propose that we use an alternate method to get the terminal size in Windows for python 2.7. This recipe was taken here:  https://gist.github.com/jtriley/1108174
