### PR TITLE
Fixed get_window_dim which was failing with Python 2.7 on Windows

### DIFF
--- a/azclishell/util.py
+++ b/azclishell/util.py
@@ -50,9 +50,9 @@ def _size_windows():
     res = windll.kernel32.GetConsoleScreenBufferInfo(h, csbi)
     if res:
         (_, _, _, _, _, left, top, right, bottom, _, _) = struct.unpack("hhhhHhhhhhh", csbi.raw)
-        sizex = right - left + 1
-        sizey = bottom - top + 1
-        return sizex, sizey
+        columns = right - left + 1
+        lines = bottom - top + 1
+        return lines, columns
 
 
 def default_style():

--- a/azclishell/util.py
+++ b/azclishell/util.py
@@ -6,6 +6,7 @@
 
 import os
 import sys
+import struct
 import platform
 
 from prompt_toolkit.styles import style_from_dict
@@ -16,8 +17,10 @@ def get_window_dim():
     """ gets the dimensions depending on python version and os"""
     version = sys.version_info
 
-    if platform.system() == 'Windows' or version >= (3, 3):
-        return _size_36_windows()
+    if version >= (3, 3):
+        return _size_36()
+    elif platform.system() == 'Windows':
+        return _size_windows()
     else:
         return _size_27()
 
@@ -28,13 +31,28 @@ def _size_27():
     return dim[0], dim[1]
 
 
-def _size_36_windows():
+def _size_36():
     """ returns the rows, columns of terminal """
     from shutil import get_terminal_size  # pylint: disable=no-name-in-module
     dim = get_terminal_size()
     if isinstance(dim, list):
         return dim[0], dim[1]
     return dim.lines, dim.columns
+
+
+def _size_windows():
+    from ctypes import windll, create_string_buffer
+    # stdin handle is -10
+    # stdout handle is -11
+    # stderr handle is -12
+    h = windll.kernel32.GetStdHandle(-12)
+    csbi = create_string_buffer(22)
+    res = windll.kernel32.GetConsoleScreenBufferInfo(h, csbi)
+    if res:
+        (_, _, _, _, _, left, top, right, bottom, _, _) = struct.unpack("hhhhHhhhhhh", csbi.raw)
+        sizex = right - left + 1
+        sizey = bottom - top + 1
+        return sizex, sizey
 
 
 def default_style():


### PR DESCRIPTION
I tried installing the shell on Windows with Python 2.7, but it would fail on launch complaining about being unable to import get_terminal_size. By looking at the file util.py, I understand that if the platform is Windows then it would go through the Python 3.6 code path and would then fail to import the get_terminal_method if we are running on Python 2.7.

I propose that we use an alternate method to get the terminal size in Windows for python 2.7. This recipe was taken here: https://gist.github.com/jtriley/1108174