### PR TITLE
Support scoping/unscoping in case there is no space between scoping symbol and command

### DIFF
--- a/azclishell/app.py
+++ b/azclishell/app.py
@@ -465,12 +465,11 @@ class Shell(object):
         return continue_flag
 
     def handle_scoping_input(self, continue_flag, cmd, text):
-        txtspt = text.split()
         default_split = text.partition(SELECT_SYMBOL['scope'])[2].split()
         cmd = cmd.replace(SELECT_SYMBOL['scope'], '')
         continue_flag = True
 
-        if SELECT_SYMBOL['scope'] == txtspt[0]:
+        if text and SELECT_SYMBOL['scope'] == text[0:2]:
             if not default_split:
                 self.default_command = ""
                 set_scope("", add=False)

--- a/azclishell/az_completer.py
+++ b/azclishell/az_completer.py
@@ -43,9 +43,8 @@ def reformat_cmd(text):
     """ reformat the text to be stripped of noise """
     # remove az if there
     text = text.replace('az', '')
-    txtsplt = text.split()
     # disregard defaulting symbols
-    if text and text[-1].isspace() and txtsplt and SELECT_SYMBOL['scope'] == txtsplt[0]:
+    if text and SELECT_SYMBOL['scope'] == text[0:2]:
         text = text.replace(SELECT_SYMBOL['scope'], "")
 
     if get_scope():


### PR DESCRIPTION
In the latest version (azure-cli-shell 0.2.2), the following (a) scoping pattern causes errors while (b) scoping pattern doesn't. Not sure if this is an expected behavior but it's very natural to me that scoping/unscoping can be done with both (a) and (b) pattern.

**(a) No space between %% and group/subgroup command**
```
az>> %%network
az>> %%network vnet
az network>> %%vnet
az network>> %%..
```

**(b) With space between %% and group/subgroup command**
```
az>> %% network
az>> %% network vnet
az network>> %% vnet
az network>> %% ..
```

Merging this PR can make both (a) and (b) work.  
Please consider!